### PR TITLE
add rviz-config argument to launch files

### DIFF
--- a/src/flock_simulator/launch/flock_simulator.launch
+++ b/src/flock_simulator/launch/flock_simulator.launch
@@ -1,6 +1,7 @@
 <launch>
     <arg name="map_name" default="4way"/>
     <arg name="n_duckies" default="3"/>
+    <arg name="rviz_config" default="$(find flock_simulator)/config/$(arg map_name).rviz"/>
 
     <node pkg="flock_simulator" name="flock_simulator_node" 
     type="flock_simulator_node.py" output="screen">
@@ -13,5 +14,6 @@
 
     <include file="$(find flock_simulator)/launch/visualization.launch">
         <arg name="map_name" value="$(arg map_name)"/>
+        <arg name="rviz_config" value="$(arg rviz_config)"/>
     </include>
 </launch>

--- a/src/flock_simulator/launch/visualization.launch
+++ b/src/flock_simulator/launch/visualization.launch
@@ -1,11 +1,11 @@
 <launch>
     <arg name="map_name" default="robotarium1"/>
+    <arg name="rviz_config" default="$(find flock_simulator)/config/$(arg map_name).rviz"/>
 
     <include 
     file="$(find duckietown_visualization)/launch/publish_map.launch">
         <arg name="map_name" value="$(arg map_name)"/>
-        <arg name="rviz_config" 
-            value="$(find flock_simulator)/config/$(arg map_name).rviz"/>
+        <arg name="rviz_config" value="$(arg rviz_config)"/>
     </include>
 
     <node pkg="duckietown_visualization" name="duckiebot_marker_publisher" 


### PR DESCRIPTION
Added the source path for the rviz-config file as an argument to the launch files of the flock_planner package.  This would be a nice feature for us from the obst_avoid team, such that we can reuse your launch file and easily use additional visualizations